### PR TITLE
Add air.toml file

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,4 @@
 ^CODEOWNERS$
 ^\.github$
 ^\.lintr$
+^[.]?air[.]toml$

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,2 @@
+[format]
+line-ending = "lf"


### PR DESCRIPTION
To enforce "lf" line endings across platforms.
Could be set to "native" instead if "lf" causes any problems.